### PR TITLE
Add base framework for Biologist quests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,5 +64,15 @@
             <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/lumine/mythic/bukkit/events/MythicMobDeathEvent.java
+++ b/src/main/java/io/lumine/mythic/bukkit/events/MythicMobDeathEvent.java
@@ -1,0 +1,28 @@
+package io.lumine.mythic.bukkit.events;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Minimal stub for compilation. Real implementation provided by MythicMobs plugin.
+ */
+public class MythicMobDeathEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    public String getMobType() { return null; }
+
+    public LivingEntity getEntity() { return null; }
+
+    public Player getKiller() { return null; }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/BiologPlugin.java
+++ b/src/main/java/org/maks/biologPlugin/BiologPlugin.java
@@ -1,17 +1,71 @@
 package org.maks.biologPlugin;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.biologPlugin.command.BiologistCommand;
+import org.maks.biologPlugin.db.DatabaseManager;
+import org.maks.biologPlugin.gui.BiologistAdminGUI;
+import org.maks.biologPlugin.gui.BiologistGUIManager;
+import org.maks.biologPlugin.listener.CooldownResetItemListener;
+import org.maks.biologPlugin.listener.MobDropListener;
+import org.maks.biologPlugin.quest.QuestDefinition;
+import org.maks.biologPlugin.quest.QuestDefinitionManager;
+import org.maks.biologPlugin.quest.QuestManager;
+import org.maks.biologPlugin.command.BiologistAdminCommand;
+
+import java.util.List;
+import java.util.Map;
 
 public final class BiologPlugin extends JavaPlugin {
 
+    private DatabaseManager databaseManager;
+    private QuestDefinitionManager questDefinitionManager;
+    private QuestManager questManager;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        saveDefaultConfig();
+        FileConfiguration config = getConfig();
+        String host = config.getString("mysql.host", "localhost");
+        int port = config.getInt("mysql.port", 3306);
+        String database = config.getString("mysql.database", "biologist_db");
+        String username = config.getString("mysql.username", "root");
+        String password = config.getString("mysql.password", "");
+        databaseManager = new DatabaseManager(host, port, database, username, password);
 
+        questManager = new QuestManager(databaseManager);
+        questDefinitionManager = new QuestDefinitionManager(databaseManager, config);
+        Map<String, QuestDefinition> questMap = questDefinitionManager.getQuestMap();
+        BiologistGUIManager guiManager = new BiologistGUIManager(questManager, questMap);
+        BiologistAdminGUI adminGUI = new BiologistAdminGUI(questDefinitionManager);
+
+        getServer().getPluginManager().registerEvents(guiManager, this);
+        getServer().getPluginManager().registerEvents(adminGUI, this);
+        getServer().getPluginManager().registerEvents(new MobDropListener(questManager, questMap), this);
+
+        // cooldown item
+        Material mat = Material.matchMaterial(config.getString("cooldown_item.id", "BOWL"));
+        String display = ChatColor.translateAlternateColorCodes('&', config.getString("cooldown_item.display", ""));
+        List<String> lore = config.getStringList("cooldown_item.lore");
+        for (int i = 0; i < lore.size(); i++) {
+            lore.set(i, ChatColor.translateAlternateColorCodes('&', lore.get(i)));
+        }
+        getServer().getPluginManager().registerEvents(new CooldownResetItemListener(questManager, mat, display, lore), this);
+
+        if (getCommand("biolog") != null) {
+            getCommand("biolog").setExecutor(new BiologistCommand(guiManager));
+        }
+        if (getCommand("biologadmin") != null) {
+            getCommand("biologadmin").setExecutor(new BiologistAdminCommand(adminGUI, questDefinitionManager));
+        }
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        if (databaseManager != null) {
+            databaseManager.close();
+        }
     }
 }

--- a/src/main/java/org/maks/biologPlugin/command/BiologistAdminCommand.java
+++ b/src/main/java/org/maks/biologPlugin/command/BiologistAdminCommand.java
@@ -1,0 +1,38 @@
+package org.maks.biologPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.biologPlugin.gui.BiologistAdminGUI;
+import org.maks.biologPlugin.quest.QuestDefinition;
+import org.maks.biologPlugin.quest.QuestDefinitionManager;
+
+public class BiologistAdminCommand implements CommandExecutor {
+    private final BiologistAdminGUI adminGUI;
+    private final QuestDefinitionManager questDefinitionManager;
+
+    public BiologistAdminCommand(BiologistAdminGUI adminGUI, QuestDefinitionManager questDefinitionManager) {
+        this.adminGUI = adminGUI;
+        this.questDefinitionManager = questDefinitionManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        if (args.length != 1) {
+            sender.sendMessage("Usage: /biologadmin <questId>");
+            return true;
+        }
+        QuestDefinition quest = questDefinitionManager.getQuest(args[0]);
+        if (quest == null) {
+            sender.sendMessage("Quest not found.");
+            return true;
+        }
+        adminGUI.open(player, quest);
+        return true;
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/command/BiologistCommand.java
+++ b/src/main/java/org/maks/biologPlugin/command/BiologistCommand.java
@@ -1,0 +1,25 @@
+package org.maks.biologPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.biologPlugin.gui.BiologistGUIManager;
+
+public class BiologistCommand implements CommandExecutor {
+    private final BiologistGUIManager guiManager;
+
+    public BiologistCommand(BiologistGUIManager guiManager) {
+        this.guiManager = guiManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        guiManager.open(player);
+        return true;
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/db/DatabaseManager.java
+++ b/src/main/java/org/maks/biologPlugin/db/DatabaseManager.java
@@ -1,0 +1,28 @@
+package org.maks.biologPlugin.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DatabaseManager {
+    private final HikariDataSource dataSource;
+
+    public DatabaseManager(String host, int port, String database, String username, String password) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?useSSL=false&characterEncoding=utf8");
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setMaximumPoolSize(10);
+        this.dataSource = new HikariDataSource(config);
+    }
+
+    public Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    public void close() {
+        dataSource.close();
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/gui/BiologistAdminGUI.java
+++ b/src/main/java/org/maks/biologPlugin/gui/BiologistAdminGUI.java
@@ -1,0 +1,85 @@
+package org.maks.biologPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.biologPlugin.quest.QuestDefinition;
+import org.maks.biologPlugin.quest.QuestDefinitionManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BiologistAdminGUI implements Listener {
+    private final QuestDefinitionManager questDefinitionManager;
+
+    public BiologistAdminGUI(QuestDefinitionManager questDefinitionManager) {
+        this.questDefinitionManager = questDefinitionManager;
+    }
+
+    public void open(Player player, QuestDefinition quest) {
+        Inventory inv = Bukkit.createInventory(player, 27, ChatColor.DARK_AQUA + "Edit Rewards:" + quest.getId());
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta fm = filler.getItemMeta();
+        fm.setDisplayName(" ");
+        filler.setItemMeta(fm);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, filler);
+        }
+        // Slots 10-16 allow items
+        if (quest.getRewards() != null) {
+            int slot = 10;
+            for (ItemStack item : quest.getRewards()) {
+                inv.setItem(slot++, item.clone());
+            }
+        }
+        inv.setItem(18, createButton(Material.LIME_WOOL, ChatColor.GREEN + "Save"));
+        inv.setItem(26, createButton(Material.RED_WOOL, ChatColor.RED + "Cancel"));
+        player.openInventory(inv);
+    }
+
+    private ItemStack createButton(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) e.getWhoClicked();
+        String title = e.getView().getTitle();
+        if (!title.startsWith(ChatColor.DARK_AQUA + "Edit Rewards:")) return;
+        e.setCancelled(true);
+        Inventory inv = e.getInventory();
+        if (e.getRawSlot() >= 10 && e.getRawSlot() <= 16) {
+            e.setCancelled(false); // allow editing
+            return;
+        }
+        QuestDefinition quest = questDefinitionManager.getQuest(title.substring((ChatColor.DARK_AQUA + "Edit Rewards:").length()));
+        if (quest == null) return;
+        if (e.getRawSlot() == 18) { // save
+            List<ItemStack> items = new ArrayList<>();
+            for (int slot = 10; slot <= 16; slot++) {
+                ItemStack item = inv.getItem(slot);
+                if (item != null && item.getType() != Material.AIR) {
+                    items.add(item.clone());
+                }
+            }
+            quest.setRewards(items);
+            questDefinitionManager.saveRewards(quest);
+            player.sendMessage(ChatColor.GREEN + "Rewards saved.");
+            player.closeInventory();
+        } else if (e.getRawSlot() == 26) {
+            player.closeInventory();
+        }
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/gui/BiologistGUIManager.java
+++ b/src/main/java/org/maks/biologPlugin/gui/BiologistGUIManager.java
@@ -1,0 +1,114 @@
+package org.maks.biologPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.biologPlugin.quest.QuestDefinition;
+import org.maks.biologPlugin.quest.QuestManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class BiologistGUIManager implements Listener {
+    private final QuestManager questManager;
+    private final Map<String, QuestDefinition> quests;
+    private final Random random = new Random();
+
+    public BiologistGUIManager(QuestManager questManager, Map<String, QuestDefinition> quests) {
+        this.questManager = questManager;
+        this.quests = quests;
+    }
+
+    public void open(Player player) {
+        QuestManager.PlayerData data = questManager.getData(player);
+        QuestDefinition quest;
+        if (data.getQuestId() == null) {
+            quest = quests.values().stream().findFirst().orElse(null);
+            if (quest == null) {
+                player.sendMessage(ChatColor.RED + "No quests configured.");
+                return;
+            }
+            data.setQuestId(quest.getId());
+            questManager.saveData(data);
+        } else {
+            quest = quests.get(data.getQuestId());
+        }
+        Inventory inv = Bukkit.createInventory(player, 27, ChatColor.DARK_GREEN + "Biologist");
+        ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+        ItemMeta fm = filler.getItemMeta();
+        fm.setDisplayName(" ");
+        filler.setItemMeta(fm);
+        for (int i = 0; i < inv.getSize(); i++) {
+            inv.setItem(i, filler);
+        }
+
+        // Quest item in slot 13
+        ItemStack questItem = new ItemStack(Material.BOOK);
+        ItemMeta meta = questItem.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + quest.getName());
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + quest.getDescription());
+        lore.add(ChatColor.YELLOW + "Progress: " + data.getProgress() + "/" + quest.getAmount());
+        lore.add(ChatColor.GREEN + "Submit item in slot 22");
+        meta.setLore(lore);
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+        questItem.setItemMeta(meta);
+        inv.setItem(13, questItem);
+
+        // Submission slot 22 empty for player to place item
+        inv.setItem(22, new ItemStack(Material.AIR));
+
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player)) return;
+        Player player = (Player) e.getWhoClicked();
+        Inventory inv = e.getInventory();
+        if (!e.getView().getTitle().equals(ChatColor.DARK_GREEN + "Biologist")) return;
+        if (e.getRawSlot() < inv.getSize()) {
+            if (e.getRawSlot() != 22) {
+                e.setCancelled(true);
+            } else {
+                // Player attempts to submit item
+                ItemStack item = e.getCurrentItem();
+                if (item == null || item.getType() == Material.AIR) return;
+                QuestManager.PlayerData data = questManager.getData(player);
+                QuestDefinition quest = quests.get(data.getQuestId());
+                if (quest == null) return;
+                boolean success = random.nextDouble() <= quest.getChance();
+                data.setLastSubmission(System.currentTimeMillis());
+                if (success) {
+                    data.setProgress(data.getProgress() + 1);
+                    player.sendMessage(ChatColor.GREEN + "Item accepted!" );
+                    if (data.getProgress() >= quest.getAmount()) {
+                        if (quest.getRewards() != null) {
+                            for (ItemStack reward : quest.getRewards()) {
+                                player.getInventory().addItem(reward.clone());
+                            }
+                        }
+                        data.setProgress(0);
+                        player.sendMessage(ChatColor.GOLD + "Quest completed!");
+                    }
+                    questManager.saveData(data);
+                    e.setCurrentItem(null);
+                } else {
+                    player.sendMessage(ChatColor.RED + "Biologist rejected your item.");
+                    questManager.saveData(data);
+                }
+                e.setCancelled(true);
+            }
+        }
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/listener/CooldownResetItemListener.java
+++ b/src/main/java/org/maks/biologPlugin/listener/CooldownResetItemListener.java
@@ -1,0 +1,43 @@
+package org.maks.biologPlugin.listener;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.biologPlugin.quest.QuestManager;
+
+import java.util.List;
+
+public class CooldownResetItemListener implements Listener {
+    private final QuestManager questManager;
+    private final Material material;
+    private final String display;
+    private final List<String> lore;
+
+    public CooldownResetItemListener(QuestManager questManager, Material material, String display, List<String> lore) {
+        this.questManager = questManager;
+        this.material = material;
+        this.display = display;
+        this.lore = lore;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent e) {
+        if (e.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = e.getItem();
+        if (item == null || item.getType() != material) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || !display.equals(meta.getDisplayName())) return;
+        if (lore != null && !lore.equals(meta.getLore())) return;
+        QuestManager.PlayerData data = questManager.getData(e.getPlayer());
+        data.setLastSubmission(0);
+        questManager.saveData(data);
+        e.getPlayer().sendMessage(ChatColor.GREEN + "Cooldown reset.");
+        item.setAmount(item.getAmount() - 1);
+        e.setCancelled(true);
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/listener/MobDropListener.java
+++ b/src/main/java/org/maks/biologPlugin/listener/MobDropListener.java
@@ -1,0 +1,43 @@
+package org.maks.biologPlugin.listener;
+
+import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.maks.biologPlugin.quest.QuestDefinition;
+import org.maks.biologPlugin.quest.QuestManager;
+
+public class MobDropListener implements Listener {
+    private final QuestManager questManager;
+    private final java.util.Map<String, QuestDefinition> quests;
+
+    public MobDropListener(QuestManager questManager, java.util.Map<String, QuestDefinition> quests) {
+        this.questManager = questManager;
+        this.quests = quests;
+    }
+
+    @EventHandler
+    public void onMythicDeath(MythicMobDeathEvent e) {
+        Player killer = e.getKiller();
+        if (killer == null) return;
+        QuestManager.PlayerData data = questManager.getData(killer);
+        QuestDefinition quest = quests.get(data.getQuestId());
+        if (quest == null) return;
+        if (!quest.getMobs().containsKey(e.getMobType())) return;
+        // Drop quest item
+        ItemStack item = new ItemStack(Material.PAPER); // placeholder material
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(ChatColor.GOLD + quest.getItemName());
+        meta.setLore(java.util.Collections.singletonList(ChatColor.GRAY + quest.getItemLore()));
+        meta.addEnchant(org.bukkit.enchantments.Enchantment.DURABILITY, 10, true);
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_UNBREAKABLE);
+        meta.setUnbreakable(true);
+        item.setItemMeta(meta);
+        e.getEntity().getWorld().dropItem(e.getEntity().getLocation(), item);
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/quest/QuestDefinition.java
+++ b/src/main/java/org/maks/biologPlugin/quest/QuestDefinition.java
@@ -1,0 +1,71 @@
+package org.maks.biologPlugin.quest;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Map;
+
+public class QuestDefinition {
+    private final String id;
+    private final String name;
+    private final String description;
+    private final Map<String, String> mobs; // mythicId -> display name
+    private final double chance;
+    private final int amount;
+    private final String itemName;
+    private final String itemLore;
+
+    private List<ItemStack> rewards;
+
+    public QuestDefinition(String id, String name, String description, Map<String, String> mobs,
+                           double chance, int amount, String itemName, String itemLore) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.mobs = mobs;
+        this.chance = chance;
+        this.amount = amount;
+        this.itemName = itemName;
+        this.itemLore = itemLore;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Map<String, String> getMobs() {
+        return mobs;
+    }
+
+    public double getChance() {
+        return chance;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public String getItemLore() {
+        return itemLore;
+    }
+
+    public List<ItemStack> getRewards() {
+        return rewards;
+    }
+
+    public void setRewards(List<ItemStack> rewards) {
+        this.rewards = rewards;
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/quest/QuestDefinitionManager.java
+++ b/src/main/java/org/maks/biologPlugin/quest/QuestDefinitionManager.java
@@ -1,0 +1,99 @@
+package org.maks.biologPlugin.quest;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.maks.biologPlugin.db.DatabaseManager;
+
+import java.lang.reflect.Type;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+public class QuestDefinitionManager {
+    private final Map<String, QuestDefinition> quests = new HashMap<>();
+    private final DatabaseManager databaseManager;
+    private final Gson gson = new Gson();
+
+    public QuestDefinitionManager(DatabaseManager databaseManager, FileConfiguration config) {
+        this.databaseManager = databaseManager;
+        loadQuests(config);
+        loadRewards();
+    }
+
+    private void loadQuests(FileConfiguration config) {
+        ConfigurationSection section = config.getConfigurationSection("quests");
+        if (section == null) return;
+
+        for (String id : section.getKeys(false)) {
+            ConfigurationSection qSec = section.getConfigurationSection(id);
+            if (qSec == null) continue;
+            String name = qSec.getString("name", id);
+            String desc = qSec.getString("desc", "");
+            Map<String, String> mobs = new HashMap<>();
+            List<String> mobList = qSec.getStringList("mobs");
+            for (String line : mobList) {
+                String[] split = line.split(":");
+                if (split.length == 2) {
+                    mobs.put(split[0], split[1]);
+                }
+            }
+            double chance = qSec.getDouble("chance");
+            int amount = qSec.getInt("amount");
+            String itemName = qSec.getString("item_name", "");
+            String itemLore = qSec.getString("item_lore", "");
+            QuestDefinition quest = new QuestDefinition(id, name, desc, mobs, chance, amount, itemName, itemLore);
+            quests.put(id, quest);
+        }
+    }
+
+    private void loadRewards() {
+        try (Connection conn = databaseManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement("SELECT quest, items FROM biologist_rewards")) {
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                String questId = rs.getString("quest");
+                String json = rs.getString("items");
+                QuestDefinition quest = quests.get(questId);
+                if (quest != null) {
+                    Type type = new TypeToken<List<ItemStack>>(){}.getType();
+                    List<ItemStack> items = gson.fromJson(json, type);
+                    quest.setRewards(items);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public QuestDefinition getQuest(String id) {
+        return quests.get(id);
+    }
+
+    public Collection<QuestDefinition> getQuests() {
+        return quests.values();
+    }
+
+    public Map<String, QuestDefinition> getQuestMap() {
+        return quests;
+    }
+
+    public void saveRewards(QuestDefinition quest) {
+        if (quest.getRewards() == null) return;
+        try (Connection conn = databaseManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement("REPLACE INTO biologist_rewards (quest, items) VALUES (?, ?)");
+        ) {
+            Type type = new TypeToken<List<ItemStack>>(){}.getType();
+            String json = gson.toJson(quest.getRewards(), type);
+            ps.setString(1, quest.getId());
+            ps.setString(2, json);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/maks/biologPlugin/quest/QuestManager.java
+++ b/src/main/java/org/maks/biologPlugin/quest/QuestManager.java
@@ -1,0 +1,106 @@
+package org.maks.biologPlugin.quest;
+
+import org.bukkit.entity.Player;
+import org.maks.biologPlugin.db.DatabaseManager;
+
+import java.sql.*;
+import java.time.Instant;
+import java.util.UUID;
+
+public class QuestManager {
+    private final DatabaseManager databaseManager;
+
+    public QuestManager(DatabaseManager databaseManager) {
+        this.databaseManager = databaseManager;
+        createTables();
+    }
+
+    private void createTables() {
+        try (Connection conn = databaseManager.getConnection();
+             Statement st = conn.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS biologist_players (uuid VARCHAR(36) PRIMARY KEY, quest VARCHAR(64), progress INT, last_submission BIGINT)");
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS biologist_rewards (quest VARCHAR(64) PRIMARY KEY, items TEXT)");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public PlayerData getData(Player player) {
+        UUID uuid = player.getUniqueId();
+        try (Connection conn = databaseManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement("SELECT quest, progress, last_submission FROM biologist_players WHERE uuid=?")) {
+            ps.setString(1, uuid.toString());
+            ResultSet rs = ps.executeQuery();
+            if (rs.next()) {
+                String quest = rs.getString("quest");
+                int progress = rs.getInt("progress");
+                long last = rs.getLong("last_submission");
+                return new PlayerData(uuid, quest, progress, last);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return new PlayerData(uuid, null, 0, 0);
+    }
+
+    public void saveData(PlayerData data) {
+        try (Connection conn = databaseManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement("REPLACE INTO biologist_players (uuid, quest, progress, last_submission) VALUES (?, ?, ?, ?)");
+        ) {
+            ps.setString(1, data.getUuid().toString());
+            ps.setString(2, data.getQuestId());
+            ps.setInt(3, data.getProgress());
+            ps.setLong(4, data.getLastSubmission());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean canSubmit(PlayerData data) {
+        long now = Instant.now().toEpochMilli();
+        return now - data.getLastSubmission() >= 24 * 60 * 60 * 1000L;
+    }
+
+    public static class PlayerData {
+        private final UUID uuid;
+        private String questId;
+        private int progress;
+        private long lastSubmission;
+
+        public PlayerData(UUID uuid, String questId, int progress, long lastSubmission) {
+            this.uuid = uuid;
+            this.questId = questId;
+            this.progress = progress;
+            this.lastSubmission = lastSubmission;
+        }
+
+        public UUID getUuid() {
+            return uuid;
+        }
+
+        public String getQuestId() {
+            return questId;
+        }
+
+        public void setQuestId(String questId) {
+            this.questId = questId;
+        }
+
+        public int getProgress() {
+            return progress;
+        }
+
+        public void setProgress(int progress) {
+            this.progress = progress;
+        }
+
+        public long getLastSubmission() {
+            return lastSubmission;
+        }
+
+        public void setLastSubmission(long lastSubmission) {
+            this.lastSubmission = lastSubmission;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,29 @@
+mysql:
+  host: localhost
+  port: 3306
+  database: biologist_db
+  username: user
+  password: pass
+
+quests:
+  quest1:
+    name: "Collect Wolf Fangs"
+    desc: "Zabij mistyczne wilki i przynieś ich kły."
+    mobs:
+      - mythic_wolf:Mystic Wolf
+      - mythic_alpha:Alpha Wolf
+    chance: 0.7
+    amount: 20
+    item_name: "Wolf Fang"
+    item_lore: "A fang destined for the Biologist"
+
+cooldown_item:
+  id: BOWL
+  display: "§6Biologist Potion"
+  enchant: DURABILITY:10
+  lore:
+    - "§o§7Right click to reset Biologist Cooldown"
+  options:
+    HideFlags: true
+    HideAttributes: true
+    Unbreakable: true

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,8 @@ name: biologPlugin
 version: '1.0-SNAPSHOT'
 main: org.maks.biologPlugin.BiologPlugin
 api-version: '1.20'
+commands:
+  biolog:
+    description: Open biologist menu
+  biologadmin:
+    description: Edit biologist quest rewards


### PR DESCRIPTION
## Summary
- add HikariCP and Gson dependencies
- implement database, quest, GUI, and listener infrastructure for Biologist plugin
- provide sample configuration and commands

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3255da24832a8a24314d4fbd2cc0