### PR TITLE
Add configurable quest item and cooldown potion handling

### DIFF
--- a/src/main/java/org/maks/biologPlugin/BiologPlugin.java
+++ b/src/main/java/org/maks/biologPlugin/BiologPlugin.java
@@ -2,7 +2,12 @@ package org.maks.biologPlugin;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.maks.biologPlugin.command.BiologistCommand;
 import org.maks.biologPlugin.db.DatabaseManager;
@@ -46,14 +51,9 @@ public final class BiologPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(adminGUI, this);
         getServer().getPluginManager().registerEvents(new MobDropListener(questManager, questMap), this);
 
-        // cooldown item
-        Material mat = Material.matchMaterial(config.getString("cooldown_item.id", "BOWL"));
-        String display = ChatColor.translateAlternateColorCodes('&', config.getString("cooldown_item.display", ""));
-        List<String> lore = config.getStringList("cooldown_item.lore");
-        for (int i = 0; i < lore.size(); i++) {
-            lore.set(i, ChatColor.translateAlternateColorCodes('&', lore.get(i)));
-        }
-        getServer().getPluginManager().registerEvents(new CooldownResetItemListener(questManager, mat, display, lore), this);
+        // Build cooldown item from config
+        ItemStack cooldownItem = buildCooldownItem(config);
+        getServer().getPluginManager().registerEvents(new CooldownResetItemListener(questManager, cooldownItem), this);
 
         if (getCommand("biolog") != null) {
             getCommand("biolog").setExecutor(new BiologistCommand(guiManager));
@@ -61,6 +61,51 @@ public final class BiologPlugin extends JavaPlugin {
         if (getCommand("biologadmin") != null) {
             getCommand("biologadmin").setExecutor(new BiologistAdminCommand(adminGUI, questDefinitionManager));
         }
+    }
+
+    private ItemStack buildCooldownItem(FileConfiguration config) {
+        Material mat = Material.matchMaterial(config.getString("cooldown_item.id", "BOWL"));
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return item;
+        meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', config.getString("cooldown_item.display", "")));
+        List<String> lore = config.getStringList("cooldown_item.lore");
+        for (int i = 0; i < lore.size(); i++) {
+            lore.set(i, ChatColor.translateAlternateColorCodes('&', lore.get(i)));
+        }
+        meta.setLore(lore);
+
+        String enchant = config.getString("cooldown_item.enchant", "");
+        if (!enchant.isEmpty()) {
+            String[] parts = enchant.split(":");
+            if (parts.length == 2) {
+                Enchantment e = Enchantment.getByName(parts[0]);
+                try {
+                    int level = Integer.parseInt(parts[1]);
+                    if (e != null) {
+                        meta.addEnchant(e, level, true);
+                    }
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+
+        ConfigurationSection opts = config.getConfigurationSection("cooldown_item.options");
+        if (opts != null) {
+            if (opts.getBoolean("HideFlags", false)) {
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE,
+                        ItemFlag.HIDE_POTION_EFFECTS, ItemFlag.HIDE_DESTROYS, ItemFlag.HIDE_PLACED_ON);
+            }
+            if (opts.getBoolean("HideAttributes", false)) {
+                meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+            }
+            if (opts.getBoolean("Unbreakable", false)) {
+                meta.setUnbreakable(true);
+            }
+        }
+
+        item.setItemMeta(meta);
+        return item;
     }
 
     @Override

--- a/src/main/java/org/maks/biologPlugin/command/BiologistAdminCommand.java
+++ b/src/main/java/org/maks/biologPlugin/command/BiologistAdminCommand.java
@@ -1,5 +1,6 @@
 package org.maks.biologPlugin.command;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -21,6 +22,10 @@ public class BiologistAdminCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
             sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        if (!player.hasPermission("biolog.admin")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
             return true;
         }
         if (args.length != 1) {

--- a/src/main/java/org/maks/biologPlugin/command/BiologistCommand.java
+++ b/src/main/java/org/maks/biologPlugin/command/BiologistCommand.java
@@ -1,5 +1,6 @@
 package org.maks.biologPlugin.command;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -17,6 +18,10 @@ public class BiologistCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
             sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        if (!player.hasPermission("biolog.use")) {
+            player.sendMessage(ChatColor.RED + "You don't have permission to use this command.");
             return true;
         }
         guiManager.open(player);

--- a/src/main/java/org/maks/biologPlugin/gui/BiologistGUIManager.java
+++ b/src/main/java/org/maks/biologPlugin/gui/BiologistGUIManager.java
@@ -165,7 +165,7 @@ public class BiologistGUIManager implements Listener {
             }
             // validation
             ItemMeta meta = item.getItemMeta();
-            if (item.getType() != Material.PAPER || meta == null ||
+            if (item.getType() != quest.getItemMaterial() || meta == null ||
                     !meta.hasDisplayName() || !meta.getDisplayName().equals(ChatColor.GOLD + quest.getItemName()) ||
                     meta.getLore() == null || meta.getLore().isEmpty() || !meta.getLore().get(0).equals(ChatColor.GRAY + quest.getItemLore()) ||
                     !meta.hasEnchant(Enchantment.DURABILITY) || meta.getEnchantLevel(Enchantment.DURABILITY) < 10) {

--- a/src/main/java/org/maks/biologPlugin/listener/CooldownResetItemListener.java
+++ b/src/main/java/org/maks/biologPlugin/listener/CooldownResetItemListener.java
@@ -1,38 +1,33 @@
 package org.maks.biologPlugin.listener;
 
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.maks.biologPlugin.quest.QuestManager;
 
-import java.util.List;
-
+/**
+ * Listener that handles usage of the special cooldown reset item. The item is
+ * fully defined by its {@link ItemStack} including enchantments and item
+ * flags, so that only properly configured items are accepted.
+ */
 public class CooldownResetItemListener implements Listener {
     private final QuestManager questManager;
-    private final Material material;
-    private final String display;
-    private final List<String> lore;
+    private final ItemStack cooldownItem;
 
-    public CooldownResetItemListener(QuestManager questManager, Material material, String display, List<String> lore) {
+    public CooldownResetItemListener(QuestManager questManager, ItemStack cooldownItem) {
         this.questManager = questManager;
-        this.material = material;
-        this.display = display;
-        this.lore = lore;
+        this.cooldownItem = cooldownItem;
     }
 
     @EventHandler
     public void onInteract(PlayerInteractEvent e) {
         if (e.getHand() != EquipmentSlot.HAND) return;
         ItemStack item = e.getItem();
-        if (item == null || item.getType() != material) return;
-        ItemMeta meta = item.getItemMeta();
-        if (meta == null || !display.equals(meta.getDisplayName())) return;
-        if (lore != null && !lore.equals(meta.getLore())) return;
+        if (item == null || !item.isSimilar(cooldownItem)) return;
+
         questManager.getData(e.getPlayer(), data -> {
             data.setLastSubmission(0);
             questManager.saveData(data);

--- a/src/main/java/org/maks/biologPlugin/listener/MobDropListener.java
+++ b/src/main/java/org/maks/biologPlugin/listener/MobDropListener.java
@@ -2,7 +2,6 @@ package org.maks.biologPlugin.listener;
 
 import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -29,7 +28,7 @@ public class MobDropListener implements Listener {
             QuestDefinition quest = quests.get(data.getQuestId());
             if (quest == null || !data.isAccepted()) return;
             if (!quest.getMobs().containsKey(e.getMobType())) return;
-            ItemStack item = new ItemStack(Material.PAPER);
+            ItemStack item = new ItemStack(quest.getItemMaterial());
             ItemMeta meta = item.getItemMeta();
             meta.setDisplayName(ChatColor.GOLD + quest.getItemName());
             meta.setLore(java.util.Collections.singletonList(ChatColor.GRAY + quest.getItemLore()));

--- a/src/main/java/org/maks/biologPlugin/quest/QuestDefinition.java
+++ b/src/main/java/org/maks/biologPlugin/quest/QuestDefinition.java
@@ -1,5 +1,6 @@
 package org.maks.biologPlugin.quest;
 
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
@@ -12,19 +13,21 @@ public class QuestDefinition {
     private final Map<String, String> mobs; // mythicId -> display name
     private final double chance;
     private final int amount;
+    private final Material itemMaterial;
     private final String itemName;
     private final String itemLore;
 
     private List<ItemStack> rewards;
 
     public QuestDefinition(String id, String name, String description, Map<String, String> mobs,
-                           double chance, int amount, String itemName, String itemLore) {
+                           double chance, int amount, Material itemMaterial, String itemName, String itemLore) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.mobs = mobs;
         this.chance = chance;
         this.amount = amount;
+        this.itemMaterial = itemMaterial;
         this.itemName = itemName;
         this.itemLore = itemLore;
     }
@@ -53,13 +56,11 @@ public class QuestDefinition {
         return amount;
     }
 
-    public String getItemName() {
-        return itemName;
-    }
+    public Material getItemMaterial() { return itemMaterial; }
 
-    public String getItemLore() {
-        return itemLore;
-    }
+    public String getItemName() { return itemName; }
+
+    public String getItemLore() { return itemLore; }
 
     public List<ItemStack> getRewards() {
         return rewards;

--- a/src/main/java/org/maks/biologPlugin/quest/QuestDefinitionManager.java
+++ b/src/main/java/org/maks/biologPlugin/quest/QuestDefinitionManager.java
@@ -3,6 +3,7 @@ package org.maks.biologPlugin.quest;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -49,9 +50,10 @@ public class QuestDefinitionManager {
             }
             double chance = qSec.getDouble("chance");
             int amount = qSec.getInt("amount");
+            Material itemMat = Material.matchMaterial(qSec.getString("item_id", "PAPER"));
             String itemName = qSec.getString("item_name", "");
             String itemLore = qSec.getString("item_lore", "");
-            QuestDefinition quest = new QuestDefinition(id, name, desc, mobs, chance, amount, itemName, itemLore);
+            QuestDefinition quest = new QuestDefinition(id, name, desc, mobs, chance, amount, itemMat, itemName, itemLore);
             quests.put(id, quest);
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,7 @@ quests:
       - mythic_alpha:Alpha Wolf
     chance: 0.7
     amount: 20
+    item_id: BONE
     item_name: "Wolf Fang"
     item_lore: "A fang destined for the Biologist"
 

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -5,5 +5,14 @@ api-version: '1.20'
 commands:
   biolog:
     description: Open biologist menu
+    permission: biolog.use
   biologadmin:
     description: Edit biologist quest rewards
+    permission: biolog.admin
+permissions:
+  biolog.use:
+    description: Allows using /biolog
+    default: true
+  biolog.admin:
+    description: Allows using /biologadmin
+    default: op


### PR DESCRIPTION
## Summary
- allow quests to define their item material instead of always using paper
- enforce enchantments and flags when using the Biologist Potion
- expose cooldown item material/enchant/flag settings in config
- remove unused biologpotion command and require permissions for /biolog and /biologadmin

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3efec72c832a8e6cc82382b8b261